### PR TITLE
fix: handle nil redis and database clients gracefully

### DIFF
--- a/internal/html/handlers/index.go
+++ b/internal/html/handlers/index.go
@@ -8,5 +8,5 @@ import (
 
 func (h *Controller) Index(w http.ResponseWriter, r *http.Request) {
 	count := h.GetPendingMessagesCount(r.Context())
-	views.IndexPage(h.livenessState.Load(), h.readinessState.Load(), h.db.IsConnected(), h.IsRedisConnected(), count, "").Render(r.Context(), w)
+	views.IndexPage(h.livenessState.Load(), h.readinessState.Load(), h.IsDBConnected(), h.IsRedisConnected(), count, "").Render(r.Context(), w)
 }

--- a/internal/producer/producer.go
+++ b/internal/producer/producer.go
@@ -23,6 +23,10 @@ func NewProducer(redisClient *redis.Client, streamName string) *Producer {
 }
 
 func (p *Producer) Publish(ctx context.Context, message string) error {
+	// Check if Redis client is initialized
+	if p.rdb == nil {
+		return errors.New("redis client is not initialized")
+	}
 
 	err := p.rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: p.streamName,
@@ -40,6 +44,11 @@ func (p *Producer) Publish(ctx context.Context, message string) error {
 }
 
 func (p *Producer) GetPendingMessagesCount(ctx context.Context, consumerGroupName string) (int64, error) {
+	// Check if Redis client is initialized
+	if p.rdb == nil {
+		return 0, nil
+	}
+
 	// Get consumer group information
 	groups, err := p.rdb.XInfoGroups(ctx, p.streamName).Result()
 	if err != nil {


### PR DESCRIPTION
Add nil checks to prevent panics when Redis or PostgreSQL are not configured:
- Add nil check in Producer.Publish and Producer.GetPendingMessagesCount
- Add IsDBConnected helper method in Controller
- Update all handlers to safely check DB connection status
- Return user-friendly error message when Redis is not configured

This allows the application to run without Redis/PostgreSQL configuration for testing purposes.