### PR TITLE
fix(lint): address golangci-lint errcheck violations

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -61,7 +61,11 @@ func main() {
 			fmt.Fprintf(os.Stderr, "error during redis initialization: %s\n", err.Error())
 			os.Exit(1)
 		}
-		defer redisClient.Close()
+		defer func() {
+			if err := redisClient.Close(); err != nil {
+				log.Printf("error closing redis client: %v\n", err)
+			}
+		}()
 
 		// Create consumer with configurable data size
 		c := consumer.NewConsumer(

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sgaunet/kubetrainer
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/a-h/templ v0.3.857

--- a/internal/consumer/consumer.go
+++ b/internal/consumer/consumer.go
@@ -104,7 +104,9 @@ func SimulateWork(ctx context.Context, sizeBytes int64) (string, error) {
 
 	// Start a goroutine to generate the data and write it to the pipe
 	go func() {
-		defer pw.Close()
+		defer func() {
+			_ = pw.Close()
+		}()
 		err := GenerateRandomData(pw, sizeBytes)
 		if err != nil {
 			errChan <- fmt.Errorf("error generating random data: %w", err)
@@ -127,22 +129,22 @@ func SimulateWork(ctx context.Context, sizeBytes int64) (string, error) {
 	for {
 		select {
 		case <-ctx.Done():
-			pr.Close()
-			pw.Close()
+			_ = pr.Close()
+			_ = pw.Close()
 			return "", ctx.Err()
 		case err := <-errChan:
 			if err != nil {
-				pr.Close() // Ensure the reader is closed on error
+				_ = pr.Close() // Ensure the reader is closed on error
 				return "", fmt.Errorf("error in data generation: %w", err)
 			}
 			// Wait for hash result
 			select {
 			case hash := <-hashChan:
-				pr.Close() // Close the reader after we've got the hash
+				_ = pr.Close() // Close the reader after we've got the hash
 				return hash, nil
 			case <-ctx.Done():
-				pr.Close()
-				pw.Close()
+				_ = pr.Close()
+				_ = pw.Close()
 				return "", ctx.Err()
 			}
 		}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -62,11 +62,12 @@ func WaitForDB(ctx context.Context, pgdsn string) error {
 			default:
 				if err == nil {
 					err = db.Ping()
-					defer db.Close()
 					if err == nil {
+						_ = db.Close()
 						close(chDBReady)
 						return
 					}
+					_ = db.Close()
 					fmt.Println("Database not ready (not pingable)")
 					time.Sleep(1 * time.Second)
 				}

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -42,7 +42,9 @@ func TestInitDB(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer pg.Close()
+	defer func() {
+		_ = pg.Close()
+	}()
 	assert.NotNil(t, pg.DB)
 	assert.Nil(t, err)
 
@@ -60,7 +62,9 @@ func TestGetDB(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer pg.Close()
+	defer func() {
+		_ = pg.Close()
+	}()
 	db := pg.GetDB()
 	assert.NotNil(t, db)
 }

--- a/internal/html/handlers/handlers.go
+++ b/internal/html/handlers/handlers.go
@@ -63,35 +63,47 @@ func (h *Controller) GetPendingMessagesCount(ctx context.Context) int64 {
 func (h *Controller) ChangeLivenessState(w http.ResponseWriter, r *http.Request) {
 	h.UpdateLivenessState()
 	count := h.GetPendingMessagesCount(r.Context())
-	views.IndexPage(h.livenessState.Load(), h.readinessState.Load(), h.IsDBConnected(), h.IsRedisConnected(), count, "").Render(r.Context(), w)
+	if err := views.IndexPage(h.livenessState.Load(), h.readinessState.Load(), h.IsDBConnected(), h.IsRedisConnected(), count, "").Render(r.Context(), w); err != nil {
+		fmt.Println("error rendering index page:", err)
+	}
 }
 
 func (h *Controller) ChangeReadinessState(w http.ResponseWriter, r *http.Request) {
 	h.UpdateReadinessState()
 	count := h.GetPendingMessagesCount(r.Context())
-	views.IndexPage(h.livenessState.Load(), h.readinessState.Load(), h.IsDBConnected(), h.IsRedisConnected(), count, "").Render(r.Context(), w)
+	if err := views.IndexPage(h.livenessState.Load(), h.readinessState.Load(), h.IsDBConnected(), h.IsRedisConnected(), count, "").Render(r.Context(), w); err != nil {
+		fmt.Println("error rendering index page:", err)
+	}
 }
 
 func (h *Controller) Readiness(w http.ResponseWriter, r *http.Request) {
 	state := h.readinessState.Load()
 	if !state {
 		w.WriteHeader(http.StatusServiceUnavailable)
-		w.Write([]byte("not ready yet"))
+		if _, err := w.Write([]byte("not ready yet")); err != nil {
+			fmt.Println("error writing readiness response:", err)
+		}
 		return
 	}
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("ok"))
+	if _, err := w.Write([]byte("ok")); err != nil {
+		fmt.Println("error writing readiness response:", err)
+	}
 }
 
 func (h *Controller) Liveness(w http.ResponseWriter, r *http.Request) {
 	state := h.livenessState.Load()
 	if !state {
 		w.WriteHeader(http.StatusServiceUnavailable)
-		w.Write([]byte("not live"))
+		if _, err := w.Write([]byte("not live")); err != nil {
+			fmt.Println("error writing liveness response:", err)
+		}
 		return
 	}
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("ok"))
+	if _, err := w.Write([]byte("ok")); err != nil {
+		fmt.Println("error writing liveness response:", err)
+	}
 }
 
 // IsDBConnected checks if database is connected
@@ -122,7 +134,9 @@ func (h *Controller) PublishTime(w http.ResponseWriter, r *http.Request) {
 	// Check if producer is initialized
 	if h.producer == nil {
 		count := h.GetPendingMessagesCount(r.Context())
-		views.IndexPage(h.livenessState.Load(), h.readinessState.Load(), h.IsDBConnected(), h.IsRedisConnected(), count, "Redis is not configured").Render(r.Context(), w)
+		if err := views.IndexPage(h.livenessState.Load(), h.readinessState.Load(), h.IsDBConnected(), h.IsRedisConnected(), count, "Redis is not configured").Render(r.Context(), w); err != nil {
+			fmt.Println("error rendering index page:", err)
+		}
 		return
 	}
 
@@ -131,10 +145,14 @@ func (h *Controller) PublishTime(w http.ResponseWriter, r *http.Request) {
 		err := h.producer.Publish(r.Context(), currentTime)
 		if err != nil {
 			count := h.GetPendingMessagesCount(r.Context())
-			views.IndexPage(h.livenessState.Load(), h.readinessState.Load(), h.IsDBConnected(), h.IsRedisConnected(), count, err.Error()).Render(r.Context(), w)
+			if renderErr := views.IndexPage(h.livenessState.Load(), h.readinessState.Load(), h.IsDBConnected(), h.IsRedisConnected(), count, err.Error()).Render(r.Context(), w); renderErr != nil {
+				fmt.Println("error rendering index page:", renderErr)
+			}
 			return
 		}
 	}
 	count := h.GetPendingMessagesCount(r.Context())
-	views.IndexPage(h.livenessState.Load(), h.readinessState.Load(), h.IsDBConnected(), h.IsRedisConnected(), count, "").Render(r.Context(), w)
+	if err := views.IndexPage(h.livenessState.Load(), h.readinessState.Load(), h.IsDBConnected(), h.IsRedisConnected(), count, "").Render(r.Context(), w); err != nil {
+		fmt.Println("error rendering index page:", err)
+	}
 }

--- a/internal/html/handlers/index.go
+++ b/internal/html/handlers/index.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/sgaunet/kubetrainer/internal/html/views"
@@ -8,5 +9,7 @@ import (
 
 func (h *Controller) Index(w http.ResponseWriter, r *http.Request) {
 	count := h.GetPendingMessagesCount(r.Context())
-	views.IndexPage(h.livenessState.Load(), h.readinessState.Load(), h.IsDBConnected(), h.IsRedisConnected(), count, "").Render(r.Context(), w)
+	if err := views.IndexPage(h.livenessState.Load(), h.readinessState.Load(), h.IsDBConnected(), h.IsRedisConnected(), count, "").Render(r.Context(), w); err != nil {
+		fmt.Println("error rendering index page:", err)
+	}
 }


### PR DESCRIPTION
- log error from deferred redisClient.Close() in cmd/main.go
- discard errors from pipe Close() calls in consumer.SimulateWork
- fix leaked db handle in database.WaitForDB loop
- wrap pg.Close() defers in database tests
- check errors from templ Render() and ResponseWriter.Write()
  in html handlers

Closes #117