### PR TITLE
docs(readme): add CI status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 [![GitHub release](https://img.shields.io/github/release/sgaunet/kubetrainer.svg)](https://github.com/sgaunet/kubetrainer/releases/latest)
 [![Go Report Card](https://goreportcard.com/badge/github.com/sgaunet/kubetrainer)](https://goreportcard.com/report/github.com/sgaunet/kubetrainer)
 ![GitHub Downloads](https://img.shields.io/github/downloads/sgaunet/kubetrainer/total)
+![Coverage](https://raw.githubusercontent.com/wiki/sgaunet/kubetrainer/coverage-badge.svg)
+[![linter](https://github.com/sgaunet/kubetrainer/actions/workflows/linter.yml/badge.svg)](https://github.com/sgaunet/kubetrainer/actions/workflows/linter.yml)
+[![coverage](https://github.com/sgaunet/kubetrainer/actions/workflows/coverage.yml/badge.svg)](https://github.com/sgaunet/kubetrainer/actions/workflows/coverage.yml)
+[![Snapshot Build](https://github.com/sgaunet/kubetrainer/actions/workflows/snapshot.yml/badge.svg)](https://github.com/sgaunet/kubetrainer/actions/workflows/snapshot.yml)
+[![Release Build](https://github.com/sgaunet/kubetrainer/actions/workflows/release.yml/badge.svg)](https://github.com/sgaunet/kubetrainer/actions/workflows/release.yml)
+[![Vulnerability Scan](https://github.com/sgaunet/kubetrainer/actions/workflows/vulnerability-scan.yml/badge.svg)](https://github.com/sgaunet/kubetrainer/actions/workflows/vulnerability-scan.yml)
+![License](https://img.shields.io/github/license/sgaunet/kubetrainer.svg)
 
 This project provide a docker image to play with in order to train yourself with kubernetes. It's actually under development.
 


### PR DESCRIPTION
Add badges for linter, coverage, snapshot/release builds, vulnerability
scan, and license. Style mirrors sgaunet/gobadger.

Closes #67