### PR TITLE
docs(readme): add low-priority project status notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,31 @@ This project is part of other projects:
 
 * https://github.com/sgaunet/kubetrainer-docs : Documentation for kubetrainer
 * https://github.com/sgaunet/helm-kubetrainer : Helm chart to deploy kubetrainer in a kubernetes cluster
+
+## 🕐 Project Status: Low Priority
+
+This project is not under active development. While the project remains functional and available for use, please be aware of the following:
+
+### What this means:
+- **Response times will be longer** - Issues and pull requests may take weeks or months to be reviewed
+- **Updates will be infrequent** - New features and non-critical bug fixes will be rare
+- **Support is limited** - Questions and discussions may not receive timely responses
+
+### We still welcome:
+- 🐛 **Bug reports** - Critical issues will eventually be addressed
+- 🔧 **Pull requests** - Well-tested contributions are appreciated
+- 💡 **Feature requests** - Ideas will be considered for future development cycles
+- 📖 **Documentation improvements** - Always helpful for the community
+
+### Before contributing:
+1. **Check existing issues** - Your concern may already be documented
+2. **Be patient** - Responses may take considerable time
+3. **Be self-sufficient** - Be prepared to fork and maintain your own version if needed
+4. **Keep it simple** - Small, focused changes are more likely to be merged
+
+### Alternative options:
+If you need active support or rapid development:
+- Look for actively maintained alternatives
+- Reach out to discuss taking over maintenance
+
+We appreciate your understanding and patience. This project remains important to us, but current priorities limit our ability to provide regular updates and support.


### PR DESCRIPTION
Adopt the standard low-priority notice block (mirrors gitlab-stats and
helmchart-helper) to set expectations on response times, updates, and
support.

Closes #66